### PR TITLE
add LASTE report type (used in A-10C)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Features:
 * Type "weather report, alt 1000, metric" to get weather at that location at an altitude of 1000 meters independent of default unit system.
 * Type "weather set, metric" to set the default unit system to metric units.
 * Type "weather set, imperial" to set the default unit system to imperial units.
+* Type "weather laste" will create a LASTE report (A-10C, on GND level +0,+2000ft,+6000ft and +12000ft).
 
 ## NOTE
 * All keywords are **CaSE inSenSITvE**.

--- a/WeatherMark.lua
+++ b/WeatherMark.lua
@@ -67,7 +67,7 @@ weathermark.unitsystem="metric"
 weathermark.keyphrase="weather"
 
 --- DCS bug regarding wrong marker vector components was fixed. If so, set to true! 
-weathermark.DCSbugfixed=false
+weathermark.DCSbugfixed=true
 
 --- Enable debug mode ==> give more output to DCS log file.
 weathermark.Debug=false
@@ -198,8 +198,13 @@ function weathermark._OnEventMarkChange(Event)
     end 
         
     -- Get weather report text.
-    local _report = weathermark._WeatherReport(vec3, _options.alt, _options.unitsystem or weathermark.unitsystem)
-      
+	local _report=nil;
+	if _options.laste then
+      _report = weathermark._Laste(vec3, _options.alt)
+	else
+      _report = weathermark._WeatherReport(vec3, _options.alt, _options.unitsystem or weathermark.unitsystem)
+    end
+
     -- Add a new mark with weather report info.
     weathermark.markid=weathermark.markid+1
     if Event.groupID > 0 then
@@ -231,14 +236,17 @@ function weathermark._MarkTextAnalysis(text)
   local switch={}
   switch.report=false
   switch.set=false
-  
+  switch.laste=false
+
   -- Check for correct keywords.
   if text:lower():find(weathermark.keyphrase.." report") or text:lower():find(weathermark.keyphrase.." request") or text:lower():find(weathermark.keyphrase.." mark") then
     switch.report=true
   elseif text:lower():find(weathermark.keyphrase.." set") then
     switch.set=true
+  elseif text:lower():find(weathermark.keyphrase.." laste") then
+    switch.laste=true
   else
-    weathermark.info(weathermark.id..'WARNING: NEITHER "REPORT"/"REQUEST" nor "SET" keywords specified!')
+    weathermark.info(weathermark.id..'WARNING: NEITHER "REPORT"/"REQUEST"/"LASTE" nor "SET" keywords specified!')
     return nil
   end
     
@@ -278,6 +286,29 @@ end
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Main weather report.
 ------------------------------------------------------------------------------------------------------------------------------------------------------------- 
+
+--- Just print LASTE (used in A-10C)
+function weathermark._Laste(vec3)
+
+	-- LASTE is in Flight Level (x100ft) and T°C
+	alt=weathermark._GetLandHeight(vec3)
+
+    local function getLASTEat(vec3, alt)
+        local T,_=atmosphere.getTemperatureAndPressure({x=vec3.x, y=alt, z=vec3.z})
+        local Dir,Vel=weathermark._GetWind(vec3, alt)
+        local laste = string.format("\nFL%02d W%03d/%02d T%d", alt * weathermark.meter2feet / 1000, Dir, Vel * weathermark.mps2knots, T-273.15)
+        return laste
+    end
+
+    local text=""
+	text=text.."LASTE:"
+	text=text..getLASTEat(vec3, alt) -- alt +0ft
+	text=text..getLASTEat(vec3, alt+610) -- alt +2000ft
+	text=text..getLASTEat(vec3, alt+1830) -- alt +6000ft
+	text=text..getLASTEat(vec3, alt+3660) -- alt +12000ft
+
+	return text
+end
 
 --- Weather Report. Report pressure QFE/QNH, temperature, wind at certain location.
 function weathermark._WeatherReport(vec3, alt, unitsystem)


### PR DESCRIPTION
Hi,

Based on @davidp57 work, i have added a "laste" report type used in A-10C

Creating a marker with "weather laste" will get a report like:

```
LASTE:
FL00 W330 T15
FL02 W345 T13
FL06 W009 T-1
FL12 W010 T-14
```

based on ground AMSL altitude (marker created on Senaki in this exemple).
